### PR TITLE
feat: show the fcd spot name of the cell a battle took place in

### DIFF
--- a/shims/poi.d.ts
+++ b/shims/poi.d.ts
@@ -19,6 +19,7 @@ declare module 'views/utils/selectors' {
     APIMstStype,
   } from 'kcsapi/api_start2/getData/response'
   import { Selector } from 'reselect'
+  import { FcdMapState } from '../views/utils/map-cell'
   interface Dictionary<T> {
     [index: string]: T
   }
@@ -40,6 +41,7 @@ declare module 'views/utils/selectors' {
       marginMagics: Dictionary<any>
     }
     shiptag: any
+    map?: FcdMapState
   }
 
   export type IShipData = [APIShip?, APIMstShip?]

--- a/views/selectors/index.ts
+++ b/views/selectors/index.ts
@@ -1,13 +1,15 @@
 import { createSelector, OutputParametricSelector, Selector } from 'reselect'
+import { memoize } from 'lodash'
 import { dateToString } from '../../lib/utils'
 import { LogContentState } from '../reducers/log-content'
 
 import CONST from '../../lib/constant'
 
-import { extensionSelectorFactory, IState } from 'views/utils/selectors'
+import { extensionSelectorFactory, fcdSelector, IState } from 'views/utils/selectors'
 import { SearchRule } from '../reducers/search-rules'
 import { DataType } from '../reducers/tab'
 import { DataTable } from '../../lib/data-co-manager'
+import { FcdMapState, resolveMapCells } from '../utils/map-cell'
 
 type PluginState = Record<DataType, LogContentState>
 
@@ -39,9 +41,31 @@ export const pluginDataSelector: Selector<IState, PluginState> = createSelector(
   (state) => state as PluginState || empty
 )
 
-export const logContentSelectorFactory = (contentType: DataType): Selector<IState, LogContentState> => {
-  return createSelector(pluginDataSelector, (pluginData) => pluginData[contentType] || emptyLogContentState)
-}
+const fcdMapSelector: Selector<IState, FcdMapState | undefined> = createSelector(
+  fcdSelector,
+  (fcd) => fcd?.map
+)
+
+// memoized so that components creating their selector on every render still
+// hit reselect's cache
+export const logContentSelectorFactory = memoize((contentType: DataType): Selector<IState, LogContentState> => {
+  const stateSelector = createSelector(
+    pluginDataSelector,
+    (pluginData) => pluginData[contentType] || emptyLogContentState
+  )
+  if (contentType !== 'attack') {
+    return stateSelector
+  }
+  // Sortie records only store the edge id of the cell a battle took place in,
+  // the readable name comes from fcd, which loads asynchronously.
+  return createSelector(
+    [stateSelector, fcdMapSelector],
+    (state, fcdMap) => {
+      const data = resolveMapCells(state.data, fcdMap)
+      return data === state.data ? state : { ...state, data }
+    }
+  )
+})
 
 const dateToDateString = (datetime: number | string): string => {
   const date = new Date(datetime)

--- a/views/utils/map-cell.ts
+++ b/views/utils/map-cell.ts
@@ -1,0 +1,68 @@
+import { DataRow, DataTable } from '../../lib/data-co-manager'
+
+/** The part of poi's `fcd.map` this module needs, see views/redux/fcd.ts of poi. */
+export type FcdMapState = Record<string, {
+  /** edge id (api_no) -> [from spot, or null when starting, to spot] */
+  route: Record<string, [string | null, string]>
+}>
+
+// `鎮守府正面海域(1-1)` or `連合艦隊、西へ(42-1 甲) | 3`
+const MAP_ID_PATTERN = /\((\d+)-(\d+)[^)]*\)/
+// `59(道中)`, where 59 is the api_no of the edge the fleet took to the cell
+const MAP_CELL_PATTERN = /^(\d+)\((.*)\)$/
+
+const MAP_INDEX = 1
+const MAP_CELL_INDEX = 2
+
+/**
+ * Prepend the name of the cell a battle took place in to the recorded edge id,
+ * e.g. `59(道中)` becomes `H (59, 道中)`. Falls back to the original text when
+ * the map is unknown to fcd.
+ */
+function resolveMapCell(
+  mapText: string,
+  cellText: string,
+  fcdMap: FcdMapState | undefined
+): string {
+  const cellMatch = MAP_CELL_PATTERN.exec(cellText)
+  if (cellMatch == null) {
+    return cellText
+  }
+  const mapMatch = MAP_ID_PATTERN.exec(mapText)
+  if (mapMatch == null) {
+    return cellText
+  }
+  const spot = fcdMap?.[`${mapMatch[1]}-${mapMatch[2]}`]?.route?.[cellMatch[1]]?.[1]
+  return spot ? `${spot} (${cellMatch[1]}, ${cellMatch[2]})` : cellText
+}
+
+let cachedFcdMap: FcdMapState | undefined
+let rowCache = new WeakMap<DataRow, DataRow>()
+
+/**
+ * Resolve the cell column of every sortie record. Rows are cached by identity
+ * so that appending a single battle does not re-resolve the whole log.
+ */
+export function resolveMapCells(data: DataTable, fcdMap: FcdMapState | undefined): DataTable {
+  if (fcdMap !== cachedFcdMap) {
+    cachedFcdMap = fcdMap
+    rowCache = new WeakMap()
+  }
+  let resolvedAny = false
+  const resolved = data.map((row) => {
+    const cached = rowCache.get(row)
+    if (cached != null) {
+      resolvedAny = resolvedAny || cached !== row
+      return cached
+    }
+    const cellText = `${row[MAP_CELL_INDEX]}`
+    const label = resolveMapCell(`${row[MAP_INDEX]}`, cellText, fcdMap)
+    const next: DataRow = label === cellText
+      ? row
+      : [row[0], row[MAP_INDEX], label, ...row.slice(3)]
+    rowCache.set(row, next)
+    resolvedAny = resolvedAny || next !== row
+    return next
+  })
+  return resolvedAny ? resolved : data
+}


### PR DESCRIPTION
The sortie log only recorded the api_no of the edge the fleet took, so the マス column read `59(道中)`. Resolve it against poi's `fcd.map` the way battle-detail does and render `H (59, 道中)` instead.

Resolution happens in logContentSelectorFactory, so the table, the column filters and the statistics panel all agree, existing logs benefit, and the names show up as soon as fcd finishes loading. The log files and CSV import/export keep the raw api_no.