### PR TITLE
feat: week / month time scales, backed by an enum

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,7 +25,9 @@ module.exports = {
     'linebreak-style': ['error', 'unix'],
     'no-console': ['warn', {'allow': ['warn', 'error']}],
     'no-var': 'error',
-    'no-unused-vars': ['warn', {'args': 'none'}],
+    // the base rule reports enum members as unused, the ts-aware one does not
+    'no-unused-vars': 'off',
+    '@typescript-eslint/no-unused-vars': ['warn', {'args': 'none'}],
     'semi': ['error', 'never'],
     'unicode-bom': 'error',
     'prefer-const': ['error', {'destructuring': 'all'}],

--- a/i18n/ja-JP.json
+++ b/i18n/ja-JP.json
@@ -50,6 +50,8 @@
   "Show by {{scale}}": "1{{scale}}ごと",
   "Day": "日",
   "Hour": "時間",
+  "Week": "週間",
+  "Month": "ヶ月",
   "Show node": "節点を表示します",
   "Hide node": "節点を非表示にします",
   "Sleep mode": "夜間モード",

--- a/i18n/zh-CN.json
+++ b/i18n/zh-CN.json
@@ -50,6 +50,8 @@
   "Show by {{scale}}": "按 {{scale}} 显示",
   "Day": "天",
   "Hour": "小时",
+  "Week": "周",
+  "Month": "月",
   "Show node": "显示节点",
   "Hide node": "隐藏节点",
   "Sleep mode": "睡眠模式",

--- a/i18n/zh-TW.json
+++ b/i18n/zh-TW.json
@@ -50,6 +50,8 @@
   "Show by {{scale}}": "按 {{scale}} 顯示",
   "Day": "天",
   "Hour": "小時",
+  "Week": "週",
+  "Month": "月",
   "Show node": "顯示節點",
   "Hide node": "隱藏節點",
   "Sleep mode": "睡眠模式",

--- a/lib/constant.ts
+++ b/lib/constant.ts
@@ -1,3 +1,12 @@
+// search rules and statistics rules refer to a data set by its index in the
+// length list: the two fixed entries below, then one entry per search rule.
+// Custom is statistics-only and means the number is typed in by hand instead.
+export enum DataSource {
+  Custom = -1,
+  AllData = 0,
+  Filtered = 1,
+}
+
 export default {
   typeList: {
     attack: 'attack',
@@ -12,8 +21,9 @@ export default {
     filteredDataChange: 'filtereddatachange',
   },
   search: {
-    rawDataIndex: 0,
-    filteredDataIndex: 1,
+    rawDataIndex: DataSource.AllData,
+    filteredDataIndex: DataSource.Filtered,
+    // search result i sits at indexBase + i + 1
     indexBase: 1,
   },
 }

--- a/views/actions/index.ts
+++ b/views/actions/index.ts
@@ -3,6 +3,7 @@ import { DataRow } from "lib/data-co-manager"
 import { DataType, TabVisibilityAction } from "../reducers/tab"
 import { ActivePageAction, ShowAmountAction } from "../reducers/page"
 import { CheckboxVisibleAction, StatisticsVisibleAction, TimeScaleAction } from "../reducers/view-control"
+import { TimeScale } from "../utils/time-scale"
 import { SearchRulesAction } from "../reducers/search-rules"
 import { StatisticsRulesAction } from "../reducers/statistics-rules"
 import { FilterKeysAction } from "../reducers/filter-keys"
@@ -107,7 +108,7 @@ export function hiddenStatisticsPanel(type: DataType): StatisticsVisibleAction {
   }
 }
 
-export function setTimeScale(val: number, type: DataType): TimeScaleAction {
+export function setTimeScale(val: TimeScale, type: DataType): TimeScaleAction {
   return {
     type: '@@poi-plugin-akashic-records/SET_TIME_SCALE',
     val: val,

--- a/views/components/resource-chart.tsx
+++ b/views/components/resource-chart.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { createSelector, Selector } from 'reselect'
 import { useSelector } from 'react-redux'
 import ReactEChartsCore from 'echarts-for-react/lib/core'
@@ -12,6 +12,13 @@ import { DataTable } from '../../lib/data-co-manager'
 import images from '../../assets/img'
 import dark from '../../assets/themes/dark'
 import macarons from '../../assets/themes/macarons'
+import {
+  filterByTimeScale,
+  nextTimeScale,
+  TimeScale,
+  timeScaleLabels,
+  toTimeScale,
+} from '../utils/time-scale'
 
 const echartPromise = import('echarts')
 
@@ -30,9 +37,21 @@ const toDateLabel = (datetime: number): string => {
   return `${date.getFullYear()}-${month}-${day} ${hour}:${minute}`
 }
 
-const toDateString = (datetime: number): string => {
-  const date = new Date(datetime)
-  return `${date.getFullYear()}/${date.getMonth() + 1}/${date.getDate()}`
+const scaleGlyphs: Record<TimeScale, string> = {
+  [TimeScale.Hour]: 'H',
+  [TimeScale.Day]: 'D',
+  [TimeScale.Week]: 'W',
+  [TimeScale.Month]: 'M',
+}
+
+// the bundled toolbox icons only cover hour and day, so every scale is drawn
+// as a glyph instead, keeping the four states of the cycle consistent
+const toScaleIcon = (scale: TimeScale, color: string): string => {
+  const svg = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 50 50">'
+    + '<text x="25" y="39" text-anchor="middle" font-family="sans-serif"'
+    + ` font-size="46" font-weight="bold" fill="${color}">${scaleGlyphs[scale]}</text>`
+    + '</svg>'
+  return `image://data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`
 }
 
 interface SelectorResult {
@@ -50,10 +69,12 @@ const AkashicResourceChart: React.FC = () => {
 
   const { t } = useTranslation('poi-plugin-akashic-records')
 
-  const [showAsDay, setShowAsDay] = useState(config.get("plugin.Akashic.resource.chart.showAsDay", true))
+  const [timeScale, setTimeScale] = useState<TimeScale>(() => toTimeScale(
+    config.get("plugin.Akashic.resource.chart.timeScale",
+      // carried over from the hour/day toggle this cycle replaces
+      config.get("plugin.Akashic.resource.chart.showAsDay", true) ? TimeScale.Day : TimeScale.Hour)
+  ))
   const [showSymbol, setShowSymbol] = useState(config.get("plugin.Akashic.resource.chart.showSymbol", false))
-  const [dataLength, setDataLength] = useState(0)
-  const [showData, setShowData] = useState<DataTable>(data)
   const echartModuleRef = useRef<any>()
 
   useEffect(() => {
@@ -64,22 +85,11 @@ const AkashicResourceChart: React.FC = () => {
     })
   }, [echartModuleRef])
 
-  const dataFilter = useCallback((data: DataTable) => {
-    let dateString = ''
-    return data.filter((item) => {
-      if (showAsDay) {
-        const tmp = toDateString(item[0])
-        if (tmp !== dateString) {
-          dateString = tmp
-          return true
-        } else {
-          return false
-        }
-      } else {
-        return true
-      }
-    })
-  }, [showAsDay])
+  // records come in newest first, the time axis reads left to right
+  const showData: DataTable = useMemo(
+    () => [...filterByTimeScale(data, timeScale)].reverse(),
+    [data, timeScale]
+  )
 
   const textColor = isDarkTheme ? '#ddd' : '#333'
 
@@ -131,27 +141,16 @@ const AkashicResourceChart: React.FC = () => {
             show: true,
             backgroundColor: '#343434',
           },
-          myShowScale: ((showAsDayValue) => {
-            const opt = showAsDayValue
-              ? {
-                title: t("Show by {{scale}}", { scale: t("Day") }),
-                icon: toIcon(images.day),
-              } : {
-                title:  t("Show by {{scale}}", { scale: t("Hour") }),
-                icon: toIcon(images.hour),
-              }
-            return {
-              show: true,
-              ...opt,
-              onclick: () => {
-                const newShowData = dataFilter(data).reverse()
-                setShowAsDay(!showAsDayValue)
-                setShowData(newShowData)
-                setDataLength(newShowData.length)
-                config.set("plugin.Akashic.resource.chart.showAsDay", !showAsDayValue)
-              },
-            }
-          })(showAsDay),
+          myShowScale: {
+            show: true,
+            title: t("Show by {{scale}}", { scale: t(timeScaleLabels[timeScale]) }),
+            icon: toScaleIcon(timeScale, textColor),
+            onclick: () => {
+              const next = nextTimeScale(timeScale)
+              setTimeScale(next)
+              config.set("plugin.Akashic.resource.chart.timeScale", next)
+            },
+          },
           myShowType: ((showSymbolValue) => {
             const opt = showSymbolValue
               ? {
@@ -328,7 +327,7 @@ const AkashicResourceChart: React.FC = () => {
       ],
       animation: false,
     }
-  }, [dataFilter, showAsDay, showData, showSymbol, dataLength, textColor])
+  }, [t, timeScale, showData, showSymbol, textColor])
 
   return (
     echartModuleRef.current ?

--- a/views/components/resource-table-area.tsx
+++ b/views/components/resource-table-area.tsx
@@ -14,6 +14,7 @@ import { setActivePage, setFilterKey, setShowAmount, setTimeScale } from '../act
 import { HTMLSelect, HTMLTable, InputGroup } from '@blueprintjs/core'
 import { IState } from 'views/utils/selectors'
 import { DataRow, DataTable } from '../../lib/data-co-manager'
+import { TimeScale, timeScaleLabels } from '../utils/time-scale'
 
 const { config } = window
 
@@ -113,7 +114,7 @@ const AkashicResourceTableArea: React.FC<AkashicResourceTableAreaT> = ({ content
     dispatch(setActivePage(activePage, contentType))
   }, [contentType])
 
-  const handleTimeScaleSelect = useCallback((timeScale: number) => {
+  const handleTimeScaleSelect = useCallback((timeScale: TimeScale) => {
     config.set("plugin.Akashic.resource.table.showTimeScale", timeScale)
     dispatch(setTimeScale(timeScale, contentType))
   }, [contentType])
@@ -125,13 +126,14 @@ const AkashicResourceTableArea: React.FC<AkashicResourceTableAreaT> = ({ content
           <HTMLSelect
             minimal
             value={showTimeScale}
-            onChange={(e) => handleTimeScaleSelect(parseInt(e.target.value))}>
-            <option key={0} value={0}>
-              {t("Show by {{scale}}", { scale: t("Hour") })}
-            </option>
-            <option key={1} value={1}>
-              {t("Show by {{scale}}", { scale: t("Day") })}
-            </option>
+            onChange={(e) => handleTimeScaleSelect(e.target.value as TimeScale)}>
+            {
+              Object.values(TimeScale).map((scale) => (
+                <option key={scale} value={scale}>
+                  {t("Show by {{scale}}", { scale: t(timeScaleLabels[scale]) })}
+                </option>
+              ))
+            }
           </HTMLSelect>
         </div>
         <div>

--- a/views/components/statistics-panel.tsx
+++ b/views/components/statistics-panel.tsx
@@ -22,7 +22,7 @@ import styled from 'styled-components'
 import { shell } from 'electron'
 
 import { DataType } from '../reducers/tab'
-import CONST from '../../lib/constant'
+import CONST, { DataSource } from '../../lib/constant'
 import Divider from '../divider'
 import { SearchRule } from '../reducers/search-rules'
 import { StatisticsRule } from '../reducers/statistics-rules'
@@ -75,13 +75,13 @@ const getSearchItems = (lens: number[], searchRules: SearchRule[]): SearchRuleWi
 function getStatisticsItems(lens: number[], statisticsRules: StatisticsRule[]): StatisticsRuleWithResult[] {
   return statisticsRules.map((item) => {
     let ret = item
-    if (item.numeratorType !== -1) {
+    if (item.numeratorType !== DataSource.Custom) {
       ret = {
         ...ret,
         numerator: lens[item.numeratorType],
       }
     }
-    if (item.denominatorType !== -1) {
+    if (item.denominatorType !== DataSource.Custom) {
       ret = {
         ...ret,
         denominator: lens[item.denominatorType],
@@ -315,7 +315,7 @@ const AkashicRecordsStatisticsPanel: React.FC<AkashicRecordsStatisticsPanelT> = 
                                 </option>
                               ), this)
                             }
-                            <option key={-1} value={-1}>{t("Custom")}</option>
+                            <option key={DataSource.Custom} value={DataSource.Custom}>{t("Custom")}</option>
                           </HTMLSelect>
                         </td>
                         <td>
@@ -350,11 +350,11 @@ const AkashicRecordsStatisticsPanel: React.FC<AkashicRecordsStatisticsPanelT> = 
                                 </option>
                               ), this)
                             }
-                            <option key={-1} value={-1}>{t("Custom")}</option>
+                            <option key={DataSource.Custom} value={DataSource.Custom}>{t("Custom")}</option>
                           </HTMLSelect>
                         </td>
                         {
-                          (statisticsItems[index].numeratorType === -1)
+                          (statisticsItems[index].numeratorType === DataSource.Custom)
                             ? (
                               <td>
                                 <InputGroup
@@ -368,7 +368,7 @@ const AkashicRecordsStatisticsPanel: React.FC<AkashicRecordsStatisticsPanelT> = 
                             )
                         }
                         {
-                          (statisticsItems[index].denominatorType === -1)
+                          (statisticsItems[index].denominatorType === DataSource.Custom)
                             ? (
                               <td>
                                 <InputGroup

--- a/views/components/table-area.tsx
+++ b/views/components/table-area.tsx
@@ -10,6 +10,7 @@ import { shell } from 'electron'
 import { DataRow, DataTable } from "lib/data-co-manager"
 import { dateToString } from '../../lib/utils'
 import { DataType, getTabs, TabVisibilityState } from '../reducers/tab'
+import { ConfigItem } from '../reducers/view-control'
 import { Popover } from 'views/components/etc/overlay'
 import Pagination from './pagination'
 import { filterSelectors, logContentSelectorFactory } from '../selectors'
@@ -169,9 +170,9 @@ const AkashicRecordsTableArea: React.FC<AkashicRecordsTableAreaT> = ({ contentTy
     dispatch(setActivePage(idx, contentType))
   }, [contentType])
 
-  let showLabel = configListChecked[0]
-  let showFilter = configListChecked[1]
-  if (configListChecked[2]) {
+  let showLabel = configListChecked[ConfigItem.ShowHeadings]
+  let showFilter = configListChecked[ConfigItem.ShowFilterBox]
+  if (configListChecked[ConfigItem.AutoSelected]) {
     showFilter = true
     showLabel = showLabel || filterKeys.some((filterKey, index) =>
       tabVisibility[index + 1] && filterKey !== ''

--- a/views/reducers/search-rules.ts
+++ b/views/reducers/search-rules.ts
@@ -1,5 +1,7 @@
 import { Reducer } from 'redux'
 
+import { DataSource } from '../../lib/constant'
+
 export interface SearchRulesAction {
   type: string;
   index?: number;
@@ -7,6 +9,7 @@ export interface SearchRulesAction {
 }
 
 export interface SearchRule {
+  // a DataSource, or the index of a search result beyond DataSource.Filtered
   baseOn: number;
   content: string;
 }
@@ -17,7 +20,7 @@ const searchRule: Reducer<SearchRule, SearchRulesAction> = (state, action) => {
   switch (action.type) {
   case '@@poi-plugin-akashic-records/ADD_SEARCH_RULE':
     return {
-      baseOn: 1,
+      baseOn: DataSource.Filtered,
       content: '',
     }
   case '@@poi-plugin-akashic-records/SET_SEARCH_RULE_BASE':
@@ -28,12 +31,12 @@ const searchRule: Reducer<SearchRule, SearchRulesAction> = (state, action) => {
     }
   case '@@poi-plugin-akashic-records/SET_SEARCH_RULE_KEY':
     return {
-      baseOn: 1,
+      baseOn: DataSource.Filtered,
       ...state,
       content: action.val as string,
     }
   default:
-    return state || { baseOn: 1, content: '' }
+    return state || { baseOn: DataSource.Filtered, content: '' }
   }
 }
 
@@ -65,7 +68,7 @@ const reducer: Reducer<SearchRulesState, SearchRulesAction> = (state, action) =>
       } else if (item.baseOn === (action.index || 0) + 2) {
         return {
           ...item,
-          baseOn: 1,
+          baseOn: DataSource.Filtered,
         }
       } else {
         return item

--- a/views/reducers/state-shape
+++ b/views/reducers/state-shape
@@ -28,4 +28,4 @@ resource
     }
   ]
   filterKeys: [string]
-  showTimeScale: int
+  showTimeScale: 'hour' | 'day' | 'week' | 'month'

--- a/views/reducers/statistics-rules.ts
+++ b/views/reducers/statistics-rules.ts
@@ -1,6 +1,9 @@
 import { Reducer } from 'redux'
 
+import { DataSource } from '../../lib/constant'
+
 export interface StatisticsRule {
+  // a DataSource, or the index of a search result beyond DataSource.Filtered
   numeratorType: number;
   denominatorType: number;
   numerator: number;
@@ -16,8 +19,8 @@ export interface StatisticsRulesAction {
 export type StatisticsRulesState = StatisticsRule[]
 
 const defaultStatisticsRule = {
-  numeratorType: 1,
-  denominatorType: 1,
+  numeratorType: DataSource.Filtered,
+  denominatorType: DataSource.Filtered,
   numerator: 0,
   denominator: 1,
 }
@@ -55,11 +58,13 @@ const statisticsRule: Reducer<StatisticsRule, StatisticsRulesAction> = (state, a
   }
 }
 
+// shifts a rule's source index after the search rule at `del` is removed,
+// falling back to the filtered set for rules that pointed at it
 function deleteIndex(old: number, del: number) {
   if (old > del + 2) {
     return old - 1
   } else if (old === del + 2) {
-    return 1
+    return DataSource.Filtered
   }
   return old
 }

--- a/views/reducers/view-control.ts
+++ b/views/reducers/view-control.ts
@@ -1,7 +1,16 @@
 import { DataType } from './tab'
 import { Reducer } from 'redux'
+import { defaultTimeScale, TimeScale, toTimeScale } from '../utils/time-scale'
 
 const { config } = window
+
+// the indices configListChecked is read at, in the order of configList below
+export enum ConfigItem {
+  ShowHeadings,
+  ShowFilterBox,
+  AutoSelected,
+  DisableFilteringWhileHidingFilterBox,
+}
 
 export const configList = [
   "Show Headings", "Show Filter-box",
@@ -63,12 +72,12 @@ export const statisticsVisible: Reducer<boolean, StatisticsVisibleAction> = (sta
 export interface TimeScaleAction {
   type: string;
   dataType: DataType;
-  val: number;
+  val: TimeScale;
 }
 
-export const showTimeScale: Reducer<number, TimeScaleAction> = (state = Number.MIN_VALUE, action) => {
-  if (state == Number.MIN_VALUE) {
-    state = config.get(`plugin.Akashic.${action.dataType}.table.showTimeScale`, 0)
+export const showTimeScale: Reducer<TimeScale, TimeScaleAction> = (state, action) => {
+  if (state == null) {
+    state = toTimeScale(config.get(`plugin.Akashic.${action.dataType}.table.showTimeScale`, defaultTimeScale))
   }
   if (action.type === '@@poi-plugin-akashic-records/SET_TIME_SCALE') {
     return action.val

--- a/views/selectors/index.ts
+++ b/views/selectors/index.ts
@@ -10,6 +10,8 @@ import { SearchRule } from '../reducers/search-rules'
 import { DataType } from '../reducers/tab'
 import { DataTable } from '../../lib/data-co-manager'
 import { FcdMapState, resolveMapCells } from '../utils/map-cell'
+import { ConfigItem } from '../reducers/view-control'
+import { defaultTimeScale, filterByTimeScale, TimeScale } from '../utils/time-scale'
 
 type PluginState = Record<DataType, LogContentState>
 
@@ -24,7 +26,7 @@ const emptyLogContentState: LogContentState = {
   searchRules: [],
   statisticsRules: [],
   filterKeys: [],
-  showTimeScale: 0,
+  showTimeScale: defaultTimeScale,
 }
 
 const empty: PluginState = {
@@ -66,11 +68,6 @@ export const logContentSelectorFactory = memoize((contentType: DataType): Select
     }
   )
 })
-
-const dateToDateString = (datetime: number | string): string => {
-  const date = new Date(datetime)
-  return `${date.getFullYear()}/${date.getMonth()}/${date.getDate()}`
-}
 
 const filterRegWindex = (data: DataTable, index: number, reg: RegExp) =>
   data.filter((row) =>
@@ -132,24 +129,7 @@ const filterWNindex = (logs: DataTable, keyword: string): DataTable => {
   }
 }
 
-const filterAsScale = (data: DataTable, showScale: number) => {
-  if (showScale === 0) {
-    return data
-  } else {
-    let dateString = ""
-    return data.filter((item) => {
-      const tmp =  dateToDateString(item[0])
-      if (tmp !== dateString) {
-        dateString = tmp
-        return true
-      } else {
-        return false
-      }
-    })
-  }
-}
-
-const resourceApplyFilter = (logs: DataTable, tabVisibility: boolean[], keyWord: string, showScale: number) => {
+const resourceApplyFilter = (logs: DataTable, tabVisibility: boolean[], keyWord: string, showScale: TimeScale) => {
   let retLogs = logs
   if (keyWord != null) {
     retLogs = retLogs.filter((row) => {
@@ -163,14 +143,16 @@ const resourceApplyFilter = (logs: DataTable, tabVisibility: boolean[], keyWord:
       })
     })
   }
-  return filterAsScale(retLogs, showScale)
+  return filterByTimeScale(retLogs, showScale)
 }
 
 const emptyArr: string[] = []
 const logSelectorFactory = () => {
   const getLogs = (state: LogContentState) => state.data
   const getFilterKeys = (state: LogContentState) =>
-    (state.configListChecked[1] || state.configListChecked[2] || !state.configListChecked[3])
+    (state.configListChecked[ConfigItem.ShowFilterBox]
+      || state.configListChecked[ConfigItem.AutoSelected]
+      || !state.configListChecked[ConfigItem.DisableFilteringWhileHidingFilterBox])
       ? state.filterKeys
       : emptyArr
   return createSelector([getLogs, getFilterKeys], filterWithIndex)

--- a/views/utils/time-scale.ts
+++ b/views/utils/time-scale.ts
@@ -1,0 +1,68 @@
+import { DataTable } from '../../lib/data-co-manager'
+
+export enum TimeScale {
+  Hour = 'hour',
+  Day = 'day',
+  Week = 'week',
+  Month = 'month',
+}
+
+export const defaultTimeScale = TimeScale.Day
+
+// the order the chart toolbox cycles through
+export const timeScales = [TimeScale.Hour, TimeScale.Day, TimeScale.Week, TimeScale.Month]
+
+export const timeScaleLabels: Record<TimeScale, string> = {
+  [TimeScale.Hour]: 'Hour',
+  [TimeScale.Day]: 'Day',
+  [TimeScale.Week]: 'Week',
+  [TimeScale.Month]: 'Month',
+}
+
+export const nextTimeScale = (scale: TimeScale): TimeScale =>
+  timeScales[(timeScales.indexOf(scale) + 1) % timeScales.length]
+
+// the table scale used to be persisted as an index: 0 for hour, 1 for day
+const legacyTimeScales = [TimeScale.Hour, TimeScale.Day]
+
+export const toTimeScale = (val: unknown): TimeScale => {
+  if (typeof val === 'number') {
+    return legacyTimeScales[val] || defaultTimeScale
+  }
+  return Object.values(TimeScale).includes(val as TimeScale)
+    ? val as TimeScale
+    : defaultTimeScale
+}
+
+// the bucket a record falls in, records sharing one are collapsed into the first
+const dateToScaleString = (datetime: number | string, scale: TimeScale): string => {
+  const date = new Date(datetime)
+  switch (scale) {
+  case TimeScale.Month:
+    return `${date.getFullYear()}/${date.getMonth()}`
+  case TimeScale.Week: {
+    // keyed by the sunday the week starts on
+    const first = new Date(date.getFullYear(), date.getMonth(), date.getDate() - date.getDay())
+    return `${first.getFullYear()}/${first.getMonth()}/${first.getDate()}`
+  }
+  default:
+    return `${date.getFullYear()}/${date.getMonth()}/${date.getDate()}`
+  }
+}
+
+// keeps the first record of every bucket, so the caller's ordering decides
+// whether that is the earliest or the latest one
+export const filterByTimeScale = (data: DataTable, scale: TimeScale): DataTable => {
+  if (scale === TimeScale.Hour) {
+    return data
+  }
+  let dateString = ""
+  return data.filter((item) => {
+    const tmp = dateToScaleString(item[0], scale)
+    if (tmp !== dateString) {
+      dateString = tmp
+      return true
+    }
+    return false
+  })
+}


### PR DESCRIPTION
## What

`showTimeScale` was a bare number — `0` for hour, `1` for day. It is now a `TimeScale` string enum with **week** and **month** added, and the default moves to **day**.

The bucketing logic lives in the new `views/utils/time-scale.ts` and is shared, so the chart groups records exactly the way the table does.

### Resource table
- Dropdown options are generated from the enum, so adding a scale later means touching the enum and its label map only.
- Values previously persisted as `0`/`1` still map to hour/day; anything unrecognised falls back to day.
- Week buckets start on Sunday; month buckets on the 1st.

### Resource chart
- The hour/day toolbox button becomes a cycle: hour → day → week → month → hour. The tooltip names the current scale.
- Its setting moves to `plugin.Akashic.resource.chart.timeScale`, defaulting to the old `showAsDay` value so nobody's view changes on upgrade.
- `assets/img.ts` only ships hour and day icons, so rather than mix bundled art with improvised art, all four icons are inline SVG glyphs (**H** / **D** / **W** / **M**) tinted with the chart's theme colour — which also makes them legible in light mode, unlike the old PNGs.

Collapsing the chart's `showData`/`dataLength`/`dataFilter` state into a single memo fixes two latent bugs along the way: it used to render unfiltered, unreversed data until the toggle was clicked, and each click filtered by the scale being *left* rather than the one selected.

## Other magic numbers turned into enums

- **`ConfigItem`** — `configListChecked` was read as `[0]`/`[1]`/`[2]`/`[3]`. Numeric enum, so the persisted `[bool, bool, bool, bool]` is untouched. The filter condition in `logSelectorFactory` was the worst offender.
- **`DataSource`** — search and statistics rules point at a data set by index: `-1` custom, `0` all data, `1` filtered, higher values being search results. The three fixed ones are now named; `CONST.search.rawDataIndex`/`filteredDataIndex` derive from them. The fields stay typed `number`, since values above `Filtered` are dynamic indices and a closed enum type would be a lie.

Not converted: `activePage`, `showAmount`, `numerator`/`denominator` (real numbers) and `tabVisibility` indices (per-`DataType` column positions).

## Notes

- `.eslintrc.js` swaps the base `no-unused-vars` for the `@typescript-eslint` version — the base rule reports every enum member as unused. Repo-wide lint is clean either way.
- New i18n keys `Week` / `Month` for ja-JP, zh-CN, zh-TW. As with the existing `Hour` / `Day`, en-US has no entries and falls through to the key.

## Testing

`tsc --noEmit` and `npm run lint:js` are clean. **Not run inside poi** — the toolbox glyphs are visually unverified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
